### PR TITLE
mkdir for scripts

### DIFF
--- a/notebooks/Setup Init Script.py
+++ b/notebooks/Setup Init Script.py
@@ -3,6 +3,7 @@
 # MAGIC 
 # MAGIC echo "#!/bin/bash" > /tmp/hail-init.sh
 # MAGIC echo "apt-get install -y libopenblas-dev libopenblas-base liblapack3" >> /tmp/hail-init.sh
+# MAGIC mkdir -p /dbfs/scripts
 # MAGIC cp -f /tmp/hail-init.sh /dbfs/scripts/hail-init.sh
 
 # COMMAND ----------


### PR DESCRIPTION
Setup Init Script.py fails if /dbfs/scripts does not already exist.  Added mkdir command to create if missing.